### PR TITLE
Update Program.cs

### DIFF
--- a/EchoTspServer/Program.cs
+++ b/EchoTspServer/Program.cs
@@ -11,7 +11,8 @@ namespace EchoServer
     {
         private readonly int _port;
         private TcpListener _listener;
-        private CancellationTokenSource _cancellationTokenSource;
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
 
         //constuctor
         public EchoServer(int port)


### PR DESCRIPTION

<img width="1919" height="938" alt="image" src="https://github.com/user-attachments/assets/33b1877f-b055-48e7-aac8-b0c5b7a56fb7" />

У процесі аналізу коду інструмент SonarLint виявив попередження типу Code Smell із ідентифікатором csharpsquid:S2933.
Це попередження вказує, що деякі поля класу отримують значення лише один раз — у конструкторі — і тому мають бути позначені ключовим словом readonly.

У нашому випадку це стосується поля, яке зберігає екземпляр об’єкта CancellationTokenSource.
Поле ініціалізується під час створення об’єкта класу, а надалі не змінюється. Тобто після запуску програми ми лише використовуємо методи цього об’єкта (наприклад, для скасування або очищення), але не присвоюємо йому нове значення.
<img width="923" height="127" alt="image" src="https://github.com/user-attachments/assets/4c8b1a58-2e15-441b-9244-8122231413be" />
