### PR TITLE
Update NetSdrClient.cs

### DIFF
--- a/NetSdrClientApp/NetSdrClient.cs
+++ b/NetSdrClientApp/NetSdrClient.cs
@@ -116,7 +116,8 @@ namespace NetSdrClientApp
 
         private void _udpClient_MessageReceived(object? sender, byte[] e)
         {
-            NetSdrMessageHelper.TranslateMessage(e, out MsgTypes type, out ControlItemCodes code, out ushort sequenceNum, out byte[] body);
+            NetSdrMessageHelper.TranslateMessage(e, out MsgTypes type, out ControlItemCodes code, out _, out byte[] body);
+
             var samples = NetSdrMessageHelper.GetSamples(16, body);
 
             Console.WriteLine($"Samples recieved: " + body.Select(b => Convert.ToString(b, toBase: 16)).Aggregate((l, r) => $"{l} {r}"));


### PR DESCRIPTION

<img width="1912" height="1029" alt="image" src="https://github.com/user-attachments/assets/1248ee84-8b48-43f0-b0f8-add090a0a1e6" />

Під час аналізу коду інструмент SonarLint виявив попередження S1481:

"Remove the unused local variable 'sequenceNum'."

У методі _udpClient_MessageReceived локальна змінна sequenceNum оголошувалася як out параметр при виклику NetSdrMessageHelper.TranslateMessage, але ніколи не використовувалася в коді.

Зайві локальні змінні засмічують код та ускладнюють його підтримку.

Видалення або заміна змінної на _ підвищує читабельність і підтримуваність (Maintainability) коду.

Логіка програми не змінюється, бо значення sequenceNum не використовувалося.
<img width="1004" height="131" alt="image" src="https://github.com/user-attachments/assets/e399ddb4-491b-44ce-9980-afb34302bf00" />
