### PR TITLE
Update Program.cs

### DIFF
--- a/EchoTspServer/Program.cs
+++ b/EchoTspServer/Program.cs
@@ -54,7 +54,7 @@ namespace EchoServer
                     byte[] buffer = new byte[8192];
                     int bytesRead;
 
-                    while (!token.IsCancellationRequested && (bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length, token)) > 0)
+                    while (!token.IsCancellationRequested && (bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), token)) > 0)
                     {
                         // Echo back the received message
                         await stream.WriteAsync(buffer, 0, bytesRead, token);


### PR DESCRIPTION

<img width="1917" height="1034" alt="image" src="https://github.com/user-attachments/assets/04bebdb7-4c5d-4fb7-b01f-dd0af867af92" />

Опис зміни (Pull Request)

Під час аналізу коду інструмент Roslyn / CA1835 виявив попередження:

"Change the 'ReadAsync' method call to use the 'Stream.ReadAsync(Memory<byte>, CancellationToken)' overload."

У методі HandleClientAsync класу EchoServer старий виклик:

bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length, token)


Використовує застарілий оверлоад ReadAsync(byte[], int, int, CancellationToken).
<img width="1291" height="130" alt="image" src="https://github.com/user-attachments/assets/f1ee6284-a4f9-49a8-8b1b-e8d0cb7a5496" />
